### PR TITLE
Update Milessis paths for TesteOBT site

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Edite `ansible/inventories/dev/group_vars/win.yml`:
 
 ```yaml
 iis_sites:
-  - name: "www.argoit.com.br"
-    hostname: "www.argoit.com.br"
+  - name: "www.testeobt.com.br"
+    hostname: "www.testeobt.com.br"
     ip: "*"
     http_port: 80
     enable_https: false
@@ -87,7 +87,7 @@ iis_sites:
     start_mode: "AlwaysRunning"
 
     classic_path: "\\\\fileserverus\\Aplicacoes\\useargo\\tmsweb\\tms_argo09"
-    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\nx_argo09"
+    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\milessis\\nx"
     fallback_classic_local: "C:\\Sites\\milessis.classic"
     fallback_nextgen_local: "C:\\Sites\\milessis.nextgen"
 
@@ -189,16 +189,16 @@ Na **VM Windows** (PowerShell Admin):
 
 ```powershell
 Import-Module WebAdministration
-Get-WebBinding -Name 'www.argoit.com.br' | fl protocol,bindingInformation,hostHeader
-Get-WebApplication -Site 'www.argoit.com.br' | select path,physicalPath,applicationPool
+Get-WebBinding -Name 'www.testeobt.com.br' | fl protocol,bindingInformation,hostHeader
+Get-WebApplication -Site 'www.testeobt.com.br' | select path,physicalPath,applicationPool
 Get-WebAppPoolState 'milessis.classic','milessis.nextgen'
 
 # Testes com host header
-Invoke-WebRequest -Headers @{Host='www.argoit.com.br'} http://127.0.0.1/milessis -UseBasicParsing | Select StatusCode
-Invoke-WebRequest -Headers @{Host='www.argoit.com.br'} http://127.0.0.1/milessis/nx -UseBasicParsing | Select StatusCode
+Invoke-WebRequest -Headers @{Host='www.testeobt.com.br'} http://127.0.0.1/milessis -UseBasicParsing | Select StatusCode
+Invoke-WebRequest -Headers @{Host='www.testeobt.com.br'} http://127.0.0.1/milessis/nx -UseBasicParsing | Select StatusCode
 ```
 
-> O site usa host header; para testar via navegador local, adicione `127.0.0.1  www.argoit.com.br` no `hosts` da VM (ou adicione um binding extra sem host header).
+> O site usa host header; para testar via navegador local, adicione `127.0.0.1  www.testeobt.com.br` no `hosts` da VM (ou adicione um binding extra sem host header).
 
 ---
 

--- a/ansible/inventories/dev/group_vars/win.yml
+++ b/ansible/inventories/dev/group_vars/win.yml
@@ -13,7 +13,7 @@ iis_sites:
 
     # Caminhos “declarativos”
     classic_path: "\\\\fileserverus\\Aplicacoes\\useargo\\tmsweb\\tms_argo09"
-    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\nx_argo09"
+    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\milessis\\nx"
     fallback_classic_local: "C:\\Sites\\milessis.classic"
     fallback_nextgen_local: "C:\\Sites\\milessis.nextgen"
 

--- a/bck/milessis.yml
+++ b/bck/milessis.yml
@@ -8,8 +8,8 @@
 
   vars:
     # ====== SITE / BINDINGS ======
-    site_name: "www.argoit.com.br"
-    site_hostname: "www.argoit.com.br"
+    site_name: "www.testeobt.com.br"
+    site_hostname: "www.testeobt.com.br"
     site_ip: "*"
     http_port: 80
 
@@ -27,7 +27,7 @@
 
     # ====== CAMINHOS (UNC desejado) ======
     classic_path: "\\\\fileserverus\\Aplicacoes\\useargo\\tmsweb\\tms_argo09"
-    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\nx_argo09"
+    nextgen_path: "\\\\fileserverus\\Aplicacoes\\useargo\\argoweb\\milessis\\nx"
 
     # Fallback local quando UNC não existir
     fallback_classic_local: "C:\\Sites\\milessis.classic"

--- a/obt/limpar_pastas_playbook.yml
+++ b/obt/limpar_pastas_playbook.yml
@@ -28,7 +28,7 @@
       - { name: "tms_argo07",     pasta: "E:\\Aplicacoes\\useargo\\tmsweb\\tms_argo07",      exc: ["images","Web.config","ApplicationInsights.config"] }
       - { name: "nx_argo08",      pasta: "E:\\Aplicacoes\\useargo\\argoweb\\nx_argo08",      exc: ["images","Web.config","ApplicationInsights.config"] }
       - { name: "tms_argo08",     pasta: "E:\\Aplicacoes\\useargo\\tmsweb\\tms_argo08",      exc: ["images","Web.config","ApplicationInsights.config"] }
-      - { name: "nx_argo09",      pasta: "E:\\Aplicacoes\\useargo\\argoweb\\nx_argo09",      exc: ["images","Web.config","ApplicationInsights.config"] }
+      - { name: "nx_milessis",    pasta: "E:\\Aplicacoes\\useargo\\argoweb\\milessis\\nx",      exc: ["images","Web.config","ApplicationInsights.config"] }
       - { name: "tms_argo09",     pasta: "E:\\Aplicacoes\\useargo\\tmsweb\\tms_argo09",      exc: ["images","Web.config","ApplicationInsights.config"] }
       - { name: "nx_argo10",      pasta: "E:\\Aplicacoes\\useargo\\argoweb\\nx_argo10",      exc: ["images","Web.config","ApplicationInsights.config"] }
       - { name: "tms_argo10",     pasta: "E:\\Aplicacoes\\useargo\\tmsweb\\tms_argo10",      exc: ["images","Web.config","ApplicationInsights.config"] }


### PR DESCRIPTION
## Summary
- point Milessis nextgen content to `argoweb/milessis/nx`
- document `www.testeobt.com.br` host and updated paths
- adjust backup and cleanup playbooks for new Milessis path

## Testing
- `ansible-playbook ansible/playbooks/deploy_iis.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb88c151b48328a9f80d9f1550cf52