### PR TITLE
Add HTTP verification for deployed IIS site

### DIFF
--- a/ansible/roles/iis_site/tasks/main.yml
+++ b/ansible/roles/iis_site/tasks/main.yml
@@ -31,3 +31,7 @@
   when: site.enable_https | default(false)
   loop: "{{ iis_sites }}"
   loop_control: { loop_var: site }
+
+- include_tasks: verify.yml
+  loop: "{{ iis_sites }}"
+  loop_control: { loop_var: site }

--- a/ansible/roles/iis_site/tasks/verify.yml
+++ b/ansible/roles/iis_site/tasks/verify.yml
@@ -1,0 +1,10 @@
+---
+- name: Validate HTTP responses from site apps
+  ansible.windows.win_uri:
+    url: "http://localhost:{{ site.http_port | default(80) }}{{ app.path }}"
+    headers:
+      Host: "{{ site.hostname }}"
+    status_code: 200
+  loop: "{{ site.apps | default([]) }}"
+  loop_control:
+    loop_var: app


### PR DESCRIPTION
## Summary
- include verify.yml in IIS site role to validate HTTP responses
- add win_uri task to check each deployed application

## Testing
- `ansible-playbook --syntax-check ansible/playbooks/deploy_iis.yml` *(fails: command not found: ansible-playbook)*
- `pip install ansible-core` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb912323888328b375284277ee59ea