### PR TITLE
Improve IIS site verification

### DIFF
--- a/ansible/roles/iis_site/tasks/verify.yml
+++ b/ansible/roles/iis_site/tasks/verify.yml
@@ -1,10 +1,15 @@
 ---
 - name: Validate HTTP responses from site apps
   ansible.windows.win_uri:
-    url: "http://localhost:{{ site.http_port | default(80) }}{{ app.path }}"
+    url: "http://127.0.0.1:{{ site.http_port | default(80) }}{{ app.path }}"
     headers:
       Host: "{{ site.hostname }}"
     status_code: 200
+    use_proxy: no
+  register: site_check
+  retries: "{{ site.verify_retries | default(5) }}"
+  delay: "{{ site.verify_delay | default(3) }}"
+  until: site_check.status_code == 200
   loop: "{{ site.apps | default([]) }}"
   loop_control:
     loop_var: app


### PR DESCRIPTION
## Summary
- improve reliability of IIS site health checks by using 127.0.0.1, disabling proxies, and retrying until HTTP 200

## Testing
- `ansible-lint ansible/roles/iis_site/tasks/verify.yml` *(fails: command not found)*
- `pip install ansible-lint` *(fails: proxy 403 Forbidden)*
- `ansible-playbook ansible/playbooks/deploy_iis.yml --syntax-check -i localhost,` *(fails: command not found)*
- `pip install ansible` *(fails: proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb945970f483288faa28875b3d7455