### PR TITLE
Use CredSSP over HTTPS for dev WinRM host

### DIFF
--- a/ansible/inventories/dev/hosts.yml
+++ b/ansible/inventories/dev/hosts.yml
@@ -5,9 +5,10 @@ win:
       ansible_user: danylo.oliveira@az.local
       ansible_password: Argo@21082025
       ansible_connection: winrm
-      ansible_port: 5985
-      ansible_winrm_transport: ntlm
-      ansible_winrm_scheme: http
+      ansible_port: 5986
+      ansible_winrm_transport: credssp
+      ansible_winrm_scheme: https
+      ansible_winrm_server_cert_validation: ignore
       ansible_winrm_operation_timeout_sec: 60
       ansible_winrm_read_timeout_sec: 120
 


### PR DESCRIPTION
## Summary
- use CredSSP transport and HTTPS port for WinRM dev host

## Testing
- `ansible-playbook ansible/playbooks/deploy_iis.yml --syntax-check` *(command not found)*
- `pip install ansible` *(proxy error: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb962e3fe48328a99412f4b1d5274c