### PR TITLE
Ensure IIS services running

### DIFF
--- a/ansible/roles/windows_baseline/tasks/main.yml
+++ b/ansible/roles/windows_baseline/tasks/main.yml
@@ -34,3 +34,13 @@
     protocol: tcp
     state: present
     enabled: yes
+
+- name: Ensure IIS service is running
+  ansible.windows.win_service:
+    name: W3SVC
+    state: started
+
+- name: Ensure Windows Process Activation Service is running
+  ansible.windows.win_service:
+    name: WAS
+    state: started


### PR DESCRIPTION
## Summary
- start the IIS (W3SVC) service during Windows baseline configuration
- ensure Windows Process Activation Service (WAS) is running

## Testing
- ⚠️ `ansible-playbook -i inventories/dev/hosts.yml playbooks/deploy_iis.yml --syntax-check` *(command not found: ansible-playbook)*
- ⚠️ `apt-get update` *(403 Forbidden accessing package repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bba164becc83289f88e1e5570252aa